### PR TITLE
Fix hdfeos5 workflow concurrency conflicts

### DIFF
--- a/.github/workflows/hdfeos5.yml
+++ b/.github/workflows/hdfeos5.yml
@@ -16,7 +16,7 @@ on:
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:
-  group: hdfeos5-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
HDF5 EOS workflows are still being cancelled if different PRs to a branch are merged close together.